### PR TITLE
Remove file lookup

### DIFF
--- a/gfklookupwidget/widgets.py
+++ b/gfklookupwidget/widgets.py
@@ -141,5 +141,4 @@ class GfkLookupWidget(django.forms.Widget):
             value=value,
             urls=json.dumps(urls),
             ct_field_name=self.ct_field_name,
-            find_image=django.contrib.admin.templatetags.admin_static.static('admin/img/selector-search.gif'),
         ))


### PR DESCRIPTION
I forgot to remove this when I removed the `{find_name}` from the template. This causes the whole template to not render mysteriously in production and is a bit of a nightmare to debug.