### PR TITLE
add missing renderer parameter for widget render method

### DIFF
--- a/gfklookupwidget/widgets.py
+++ b/gfklookupwidget/widgets.py
@@ -48,7 +48,7 @@ class GfkLookupWidget(django.forms.Widget):
 
         super(GfkLookupWidget, self).__init__(*args, **kwargs)
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         model = self.parent_field.model
         ct_field = self.parent_field.model._meta.get_field(self.ct_field_name)
         choices = ct_field.get_choices()


### PR DESCRIPTION
In Django 2.1 support for widget method `render()` without optional parameter `renderer` is dropped.
This fixes an error in admin interface:

`render () got an unexpected keyword argument 'renderer'`