### PR TITLE
Remove an unused import

### DIFF
--- a/gfklookupwidget/widgets.py
+++ b/gfklookupwidget/widgets.py
@@ -20,7 +20,6 @@ try:
     from django.urls import reverse, NoReverseMatch
 except ImportError:
     from django.core.urlresolvers import reverse, NoReverseMatch
-import django.contrib.admin.templatetags.admin_static
 import django.forms
 
 


### PR DESCRIPTION
`admin_static` was unused and has been removed in Django 3.0