### PR TITLE
Stopping event propagation to skip default Django event handler.

### DIFF
--- a/gfklookupwidget/widgets.py
+++ b/gfklookupwidget/widgets.py
@@ -110,6 +110,7 @@ class GfkLookupWidget(django.forms.Widget):
                     function gfklookupwidget_{uniq}_click($, element, event) {{
                         if (event) {{
                             event.preventDefault();
+                            event.stopPropagation();
                         }}
 
                         var urls = {urls};


### PR DESCRIPTION
This is a better solution to stop the default Django event to be handled. This will solve the magnifying glass opening a pop-up when no content type is selected. Now it will just show the alert, but no pop-up will open.